### PR TITLE
Add initialCountdown

### DIFF
--- a/lib/models/workout_config.dart
+++ b/lib/models/workout_config.dart
@@ -6,6 +6,7 @@ class WorkoutConfig {
   final int secondsPerSet;
   final int numberOfSets;
   final int restBetweenSets;
+  final int initialCountdown;
 
   const WorkoutConfig({
     this.burpeeType = BurpeeType.militarySixCount,
@@ -13,6 +14,7 @@ class WorkoutConfig {
     this.secondsPerSet = 20,
     this.numberOfSets = 10,
     this.restBetweenSets = 4,
+    this.initialCountdown = 10,
   });
 
   factory WorkoutConfig.forBurpeeType(BurpeeType type) {
@@ -24,6 +26,7 @@ class WorkoutConfig {
           secondsPerSet: 20,
           numberOfSets: 10,
           restBetweenSets: 4,
+          initialCountdown: 10,
         );
       case BurpeeType.navySeal:
         return const WorkoutConfig(
@@ -32,6 +35,7 @@ class WorkoutConfig {
           secondsPerSet: 15,
           numberOfSets: 10,
           restBetweenSets: 13,
+          initialCountdown: 10,
         );
     }
   }
@@ -42,6 +46,7 @@ class WorkoutConfig {
     int? secondsPerSet,
     int? numberOfSets,
     int? restBetweenSets,
+    int? initialCountdown,
   }) {
     return WorkoutConfig(
       burpeeType: burpeeType ?? this.burpeeType,
@@ -49,6 +54,7 @@ class WorkoutConfig {
       secondsPerSet: secondsPerSet ?? this.secondsPerSet,
       numberOfSets: numberOfSets ?? this.numberOfSets,
       restBetweenSets: restBetweenSets ?? this.restBetweenSets,
+      initialCountdown: initialCountdown ?? this.initialCountdown,
     );
   }
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -150,6 +150,15 @@ class _HomeScreenState extends State<HomeScreen> {
                 _updateConfig(_config.copyWith(restBetweenSets: value));
               },
             ),
+            _buildNumberInput(
+              label: 'Initial Countdown (sec)',
+              value: _config.initialCountdown,
+              min: 3,
+              max: 30,
+              onChanged: (value) {
+                _updateConfig(_config.copyWith(initialCountdown: value));
+              },
+            ),
           ],
         ),
       ),

--- a/lib/services/timer_service.dart
+++ b/lib/services/timer_service.dart
@@ -21,9 +21,8 @@ class TimerService extends ChangeNotifier {
   int _restSeconds = 0;
   int _repsPerSet = 0;
   int _lastRep = 0;
+  int _initialCountdownSeconds = 10;
   final AudioService _audioService;
-
-  static const int _countdownSeconds = 3;
 
   TimerService({AudioService? audioService})
       : _audioService = audioService ?? AudioService();
@@ -57,7 +56,7 @@ class TimerService extends ChangeNotifier {
   double get progress {
     if (_state == TimerState.idle || _state == TimerState.finished) return 0;
     if (_state == TimerState.countdown) {
-      return 1 - (_currentSeconds / _countdownSeconds);
+      return 1 - (_currentSeconds / _initialCountdownSeconds);
     }
     if (_state == TimerState.work) {
       return 1 - (_currentSeconds / _workSeconds);
@@ -75,6 +74,7 @@ class TimerService extends ChangeNotifier {
     _workSeconds = config.secondsPerSet;
     _restSeconds = config.restBetweenSets;
     _repsPerSet = config.repsPerSet;
+    _initialCountdownSeconds = config.initialCountdown;
     _currentSet = 1;
 
     _startCountdown();
@@ -82,9 +82,7 @@ class TimerService extends ChangeNotifier {
 
   void _startCountdown() {
     _state = TimerState.countdown;
-    _currentSeconds = _countdownSeconds;
-    // Play first countdown beep immediately
-    _audioService.playCountdownBeep();
+    _currentSeconds = _initialCountdownSeconds;
     notifyListeners();
     _startTimer();
   }
@@ -116,8 +114,8 @@ class TimerService extends ChangeNotifier {
   void _tick() {
     if (_currentSeconds > 1) {
       _currentSeconds--;
-      // Play countdown beep for each second during countdown
-      if (_state == TimerState.countdown) {
+      // Play countdown beep in last 3 seconds of initial countdown
+      if (_state == TimerState.countdown && _currentSeconds <= 3) {
         _audioService.playCountdownBeep();
       }
       // Play countdown beep in last 3 seconds of work period

--- a/test/models/workout_config_test.dart
+++ b/test/models/workout_config_test.dart
@@ -13,6 +13,7 @@ void main() {
         expect(config.secondsPerSet, equals(20));
         expect(config.numberOfSets, equals(10));
         expect(config.restBetweenSets, equals(4));
+        expect(config.initialCountdown, equals(10));
       });
     });
 
@@ -29,6 +30,7 @@ void main() {
         expect(copy.secondsPerSet, equals(config.secondsPerSet));
         expect(copy.numberOfSets, equals(config.numberOfSets));
         expect(copy.restBetweenSets, equals(config.restBetweenSets));
+        expect(copy.initialCountdown, equals(config.initialCountdown));
       });
 
       test('creates exact copy when no parameters provided', () {
@@ -38,6 +40,7 @@ void main() {
           secondsPerSet: 30,
           numberOfSets: 5,
           restBetweenSets: 15,
+          initialCountdown: 15,
         );
         final copy = config.copyWith();
 
@@ -46,6 +49,15 @@ void main() {
         expect(copy.secondsPerSet, equals(config.secondsPerSet));
         expect(copy.numberOfSets, equals(config.numberOfSets));
         expect(copy.restBetweenSets, equals(config.restBetweenSets));
+        expect(copy.initialCountdown, equals(config.initialCountdown));
+      });
+
+      test('copies initialCountdown correctly', () {
+        const config = WorkoutConfig();
+        final copy = config.copyWith(initialCountdown: 20);
+
+        expect(copy.initialCountdown, equals(20));
+        expect(copy.repsPerSet, equals(config.repsPerSet));
       });
     });
 

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -19,24 +19,25 @@ void main() {
         expect(find.text('Seconds per Set'), findsOneWidget);
         expect(find.text('Number of Sets'), findsOneWidget);
         expect(find.text('Rest Between Sets (sec)'), findsOneWidget);
+        expect(find.text('Initial Countdown (sec)'), findsOneWidget);
 
         // Verify default values are displayed in text fields
         final textFields = find.byType(TextFormField);
-        expect(textFields, findsNWidgets(4));
+        expect(textFields, findsNWidgets(5));
 
-        // Check default values (5, 20, 10, 4)
+        // Check default values (5, 20, 10, 4, 10)
         expect(find.text('5'), findsOneWidget); // Reps
         expect(find.text('20'), findsOneWidget); // Seconds
-        expect(find.text('10'), findsOneWidget); // Sets
+        expect(find.text('10'), findsNWidgets(2)); // Sets and Initial Countdown both default to 10
         expect(find.text('4'), findsOneWidget); // Rest
       });
 
       testWidgets('displays plus and minus buttons for each input', (tester) async {
         await tester.pumpWidget(createTestWidget());
 
-        // 4 inputs * 2 buttons each = 8 icon buttons
-        expect(find.byIcon(Icons.add), findsNWidgets(4));
-        expect(find.byIcon(Icons.remove), findsNWidgets(4));
+        // 5 inputs * 2 buttons each = 10 icon buttons
+        expect(find.byIcon(Icons.add), findsNWidgets(5));
+        expect(find.byIcon(Icons.remove), findsNWidgets(5));
       });
     });
 

--- a/test/services/timer_service_test.dart
+++ b/test/services/timer_service_test.dart
@@ -98,20 +98,20 @@ void main() {
         expect(timerService.state, equals(TimerState.countdown));
       });
 
-      test('sets countdown seconds to 3', () async {
+      test('sets countdown seconds to configured initialCountdown', () async {
         const config = WorkoutConfig();
 
         await timerService.startWorkout(config);
 
-        expect(timerService.currentSeconds, equals(3));
+        expect(timerService.currentSeconds, equals(10));
       });
 
-      test('plays countdown beep on start', () async {
-        const config = WorkoutConfig();
+      test('sets countdown seconds to custom initialCountdown', () async {
+        const config = WorkoutConfig(initialCountdown: 5);
 
         await timerService.startWorkout(config);
 
-        verify(mockAudioService.playCountdownBeep()).called(1);
+        expect(timerService.currentSeconds, equals(5));
       });
     });
 
@@ -137,8 +137,8 @@ void main() {
         const config = WorkoutConfig();
         await timerService.startWorkout(config);
 
-        // At start of countdown (3 seconds remaining out of 3)
-        // progress = 1 - (3/3) = 0
+        // At start of countdown (10 seconds remaining out of 10)
+        // progress = 1 - (10/10) = 0
         expect(timerService.progress, equals(0));
       });
     });
@@ -218,17 +218,47 @@ void main() {
     });
 
     group('timer tick simulation', () {
-      test('countdown decrements and plays beep each second', () {
+      test('countdown plays beep only in last 3 seconds', () {
+        fakeAsync((async) {
+          const config = WorkoutConfig(initialCountdown: 5);
+          timerService.startWorkout(config);
+          async.flushMicrotasks();
+
+          // Fast-forward 1 second (5 -> 4, no beep yet)
+          async.elapse(const Duration(seconds: 1));
+          verifyNever(mockAudioService.playCountdownBeep());
+
+          // At 2 seconds elapsed (5 -> 4 -> 3), beep should play
+          async.elapse(const Duration(seconds: 1));
+          verify(mockAudioService.playCountdownBeep()).called(1);
+
+          // At 3 seconds elapsed (3 -> 2), another beep
+          async.elapse(const Duration(seconds: 1));
+          verify(mockAudioService.playCountdownBeep()).called(2);
+        });
+      });
+
+      test('initial countdown with default 10 seconds plays beep in last 3', () {
         fakeAsync((async) {
           const config = WorkoutConfig();
           timerService.startWorkout(config);
           async.flushMicrotasks();
 
-          // Fast-forward time to simulate tick
-          async.elapse(const Duration(seconds: 1));
+          // Fast-forward past first 6 seconds (no beeps yet, at 4 seconds remaining)
+          async.elapse(const Duration(seconds: 6));
+          verifyNever(mockAudioService.playCountdownBeep());
 
-          // Should have played additional beep
-          verify(mockAudioService.playCountdownBeep()).called(greaterThan(1));
+          // At 7 seconds elapsed (10 -> ... -> 3), beep should play
+          async.elapse(const Duration(seconds: 1));
+          verify(mockAudioService.playCountdownBeep()).called(1);
+
+          // Continue to 2 seconds remaining
+          async.elapse(const Duration(seconds: 1));
+          verify(mockAudioService.playCountdownBeep()).called(2);
+
+          // Continue to 1 second remaining
+          async.elapse(const Duration(seconds: 1));
+          verify(mockAudioService.playCountdownBeep()).called(3);
         });
       });
     });
@@ -239,6 +269,7 @@ void main() {
           const config = WorkoutConfig(
             repsPerSet: 5,
             secondsPerSet: 20,
+            initialCountdown: 3,
           );
           timerService.startWorkout(config);
           async.flushMicrotasks();
@@ -254,6 +285,7 @@ void main() {
           const config = WorkoutConfig(
             repsPerSet: 0,
             secondsPerSet: 20,
+            initialCountdown: 3,
           );
           timerService.startWorkout(config);
           async.flushMicrotasks();
@@ -269,6 +301,7 @@ void main() {
             repsPerSet: 5,
             secondsPerSet: 20,
             numberOfSets: 1,
+            initialCountdown: 3,
           );
           timerService.startWorkout(config);
           async.flushMicrotasks();
@@ -288,6 +321,7 @@ void main() {
             repsPerSet: 5,
             secondsPerSet: 20,
             numberOfSets: 1,
+            initialCountdown: 3,
           );
           timerService.startWorkout(config);
           async.flushMicrotasks();
@@ -308,6 +342,7 @@ void main() {
             repsPerSet: 5,
             secondsPerSet: 20,
             numberOfSets: 1,
+            initialCountdown: 3,
           );
           timerService.startWorkout(config);
           async.flushMicrotasks();
@@ -326,6 +361,7 @@ void main() {
             repsPerSet: 1,
             secondsPerSet: 10,
             numberOfSets: 1,
+            initialCountdown: 3,
           );
           timerService.startWorkout(config);
           async.flushMicrotasks();
@@ -345,6 +381,7 @@ void main() {
             repsPerSet: 3,
             secondsPerSet: 20,
             numberOfSets: 1,
+            initialCountdown: 3,
           );
           timerService.startWorkout(config);
           async.flushMicrotasks();
@@ -366,6 +403,7 @@ void main() {
             repsPerSet: 5,
             secondsPerSet: 20,
             numberOfSets: 1,
+            initialCountdown: 3,
           );
           timerService.startWorkout(config);
           async.flushMicrotasks();
@@ -388,6 +426,7 @@ void main() {
             repsPerSet: 5,
             secondsPerSet: 20,
             numberOfSets: 1,
+            initialCountdown: 3,
           );
           timerService.startWorkout(config);
           async.flushMicrotasks();
@@ -409,6 +448,7 @@ void main() {
             repsPerSet: 5,
             secondsPerSet: 20,
             numberOfSets: 1,
+            initialCountdown: 3,
           );
           timerService.startWorkout(config);
           async.flushMicrotasks();
@@ -430,6 +470,7 @@ void main() {
             repsPerSet: 1,
             secondsPerSet: 10,
             numberOfSets: 1,
+            initialCountdown: 3,
           );
           timerService.startWorkout(config);
           async.flushMicrotasks();


### PR DESCRIPTION
## Summary

- Add configurable initial countdown setting to WorkoutConfig with 10 second default
- Update TimerService to use configurable countdown that plays audio beeps only in last 3 seconds
- Add "Initial Countdown (sec)" input field to HomeScreen UI with range 3-30 seconds
- Update existing tests to handle new countdown behavior and add new test coverage

## Test plan

- [ ] Verify initial countdown field appears in workout configuration UI
- [ ] Verify default value is 10 seconds
- [ ] Verify countdown can be adjusted between 3-30 seconds using +/- buttons
- [ ] Start a workout and verify countdown begins at configured value
- [ ] Verify audio beeps only play during last 3 seconds of initial countdown
- [ ] Verify workout transitions correctly from countdown to first work set
- [ ] Run `make test` to ensure all unit tests pass

Closes #16

