### PR TITLE
Post Workout Questionnaire

### DIFF
--- a/lib/models/workout.dart
+++ b/lib/models/workout.dart
@@ -11,6 +11,9 @@ class Workout {
   final int restBetweenSets;
   final bool completed;
   final int completedSets;
+  final bool isCompleted;
+  final bool isCompletedInTime;
+  final int elapsedSeconds;
 
   Workout({
     required this.id,
@@ -22,6 +25,9 @@ class Workout {
     required this.restBetweenSets,
     this.completed = false,
     this.completedSets = 0,
+    this.isCompleted = false,
+    this.isCompletedInTime = false,
+    this.elapsedSeconds = 0,
   });
 
   int get totalReps => repsPerSet * completedSets;
@@ -40,6 +46,9 @@ class Workout {
     int? restBetweenSets,
     bool? completed,
     int? completedSets,
+    bool? isCompleted,
+    bool? isCompletedInTime,
+    int? elapsedSeconds,
   }) {
     return Workout(
       id: id ?? this.id,
@@ -51,6 +60,9 @@ class Workout {
       restBetweenSets: restBetweenSets ?? this.restBetweenSets,
       completed: completed ?? this.completed,
       completedSets: completedSets ?? this.completedSets,
+      isCompleted: isCompleted ?? this.isCompleted,
+      isCompletedInTime: isCompletedInTime ?? this.isCompletedInTime,
+      elapsedSeconds: elapsedSeconds ?? this.elapsedSeconds,
     );
   }
 
@@ -65,6 +77,9 @@ class Workout {
       'restBetweenSets': restBetweenSets,
       'completed': completed,
       'completedSets': completedSets,
+      'isCompleted': isCompleted,
+      'isCompletedInTime': isCompletedInTime,
+      'elapsedSeconds': elapsedSeconds,
     };
   }
 
@@ -79,6 +94,9 @@ class Workout {
       restBetweenSets: json['restBetweenSets'] as int,
       completed: json['completed'] as bool,
       completedSets: json['completedSets'] as int,
+      isCompleted: json['isCompleted'] as bool? ?? false,
+      isCompletedInTime: json['isCompletedInTime'] as bool? ?? false,
+      elapsedSeconds: json['elapsedSeconds'] as int? ?? 0,
     );
   }
 

--- a/lib/screens/post_workout_questionnaire_screen.dart
+++ b/lib/screens/post_workout_questionnaire_screen.dart
@@ -1,0 +1,288 @@
+import 'package:flutter/material.dart';
+import '../models/workout_config.dart';
+
+class PostWorkoutQuestionnaireScreen extends StatefulWidget {
+  final WorkoutConfig config;
+  final int elapsedSeconds;
+
+  const PostWorkoutQuestionnaireScreen({
+    super.key,
+    required this.config,
+    required this.elapsedSeconds,
+  });
+
+  @override
+  State<PostWorkoutQuestionnaireScreen> createState() =>
+      _PostWorkoutQuestionnaireScreenState();
+}
+
+class _PostWorkoutQuestionnaireScreenState
+    extends State<PostWorkoutQuestionnaireScreen> {
+  bool? _didCompleteAllSets;
+  bool? _didCompleteInTime;
+  bool _isSubmitting = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (!didPop) {
+          await _onWillPop();
+        }
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Workout Complete!'),
+          automaticallyImplyLeading: false,
+        ),
+        body: SafeArea(
+          child: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.all(24.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                const SizedBox(height: 20),
+                const Text(
+                  'Great job!',
+                  style: TextStyle(
+                    fontSize: 28,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 40),
+                _buildQuestion1Card(),
+                const SizedBox(height: 20),
+                if (_didCompleteAllSets == true) ...[
+                  _buildQuestion2Card(),
+                  const SizedBox(height: 20),
+                ],
+                const SizedBox(height: 40),
+                _buildSubmitButton(),
+                const SizedBox(height: 20),
+              ],
+            ),
+          ),
+        ),
+      ),
+      ),
+    );
+  }
+
+  Widget _buildQuestion1Card() {
+    return Card(
+      elevation: 4,
+      child: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              'Did you complete all the sets?',
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 20),
+            Row(
+              children: [
+                Expanded(
+                  child: _buildOptionButton(
+                    label: 'YES',
+                    isSelected: _didCompleteAllSets == true,
+                    onTap: () {
+                      setState(() {
+                        _didCompleteAllSets = true;
+                      });
+                    },
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: _buildOptionButton(
+                    label: 'NO',
+                    isSelected: _didCompleteAllSets == false,
+                    onTap: () {
+                      setState(() {
+                        _didCompleteAllSets = false;
+                        _didCompleteInTime = false; // Reset Q2 if Q1 is No
+                      });
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildQuestion2Card() {
+    final elapsedMinutes = (widget.elapsedSeconds / 60).floor();
+    final elapsedSecondsRemainder = widget.elapsedSeconds % 60;
+    final timeDisplay =
+        '$elapsedMinutes:${elapsedSecondsRemainder.toString().padLeft(2, '0')}';
+
+    return Card(
+      elevation: 4,
+      child: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              'Did you complete the workout in less than 5 minutes?',
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Your time: $timeDisplay',
+              style: TextStyle(
+                fontSize: 14,
+                color: Colors.grey[600],
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 20),
+            Row(
+              children: [
+                Expanded(
+                  child: _buildOptionButton(
+                    label: 'YES',
+                    isSelected: _didCompleteInTime == true,
+                    onTap: () {
+                      setState(() {
+                        _didCompleteInTime = true;
+                      });
+                    },
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: _buildOptionButton(
+                    label: 'NO',
+                    isSelected: _didCompleteInTime == false,
+                    onTap: () {
+                      setState(() {
+                        _didCompleteInTime = false;
+                      });
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildOptionButton({
+    required String label,
+    required bool isSelected,
+    required VoidCallback onTap,
+  }) {
+    return ElevatedButton(
+      onPressed: onTap,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: isSelected ? Colors.green : Colors.grey[300],
+        foregroundColor: isSelected ? Colors.white : Colors.black87,
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        elevation: isSelected ? 4 : 1,
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(
+          fontSize: 16,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSubmitButton() {
+    final isEnabled = _didCompleteAllSets != null && !_isSubmitting;
+
+    return ElevatedButton(
+      onPressed: isEnabled ? _handleSubmit : null,
+      style: ElevatedButton.styleFrom(
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        backgroundColor: Colors.blue,
+        disabledBackgroundColor: Colors.grey[400],
+      ),
+      child: _isSubmitting
+          ? const SizedBox(
+              height: 20,
+              width: 20,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+              ),
+            )
+          : const Text(
+              'SUBMIT',
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
+    );
+  }
+
+  Future<void> _handleSubmit() async {
+    setState(() {
+      _isSubmitting = true;
+    });
+
+    // Return the results to the previous screen
+    if (mounted) {
+      Navigator.pop(context, {
+        'isCompleted': _didCompleteAllSets ?? false,
+        'isCompletedInTime': _didCompleteInTime ?? false,
+      });
+    }
+  }
+
+  Future<bool> _onWillPop() async {
+    final shouldLeave = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Leave without saving?'),
+        content: const Text(
+          'Your workout will be saved with default values if you leave now.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('CANCEL'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('LEAVE'),
+          ),
+        ],
+      ),
+    );
+
+    if (shouldLeave == true && mounted) {
+      // Return default values
+      Navigator.pop(context, {
+        'isCompleted': false,
+        'isCompletedInTime': false,
+      });
+      return false; // Prevent default pop
+    }
+
+    return false; // Don't pop by default
+  }
+}

--- a/lib/screens/timer_screen.dart
+++ b/lib/screens/timer_screen.dart
@@ -9,6 +9,7 @@ import '../services/storage_service.dart';
 import '../services/workout_service.dart';
 import '../providers/auth_provider.dart';
 import 'package:uuid/uuid.dart';
+import 'post_workout_questionnaire_screen.dart';
 
 class TimerScreen extends StatefulWidget {
   final WorkoutConfig config;
@@ -47,11 +48,40 @@ class _TimerScreenState extends State<TimerScreen> {
   void _onTimerUpdate() {
     setState(() {});
     if (_timerService.state == TimerState.finished) {
-      _saveWorkout(completed: true);
+      _showPostWorkoutQuestionnaire();
     }
   }
 
-  Future<void> _saveWorkout({required bool completed}) async {
+  Future<void> _showPostWorkoutQuestionnaire() async {
+    if (!mounted) return;
+
+    final result = await Navigator.push<Map<String, dynamic>>(
+      context,
+      MaterialPageRoute(
+        builder: (context) => PostWorkoutQuestionnaireScreen(
+          config: widget.config,
+          elapsedSeconds: _timerService.elapsedWorkoutSeconds,
+        ),
+        fullscreenDialog: true,
+      ),
+    );
+
+    if (!mounted) return;
+
+    await _saveWorkout(
+      completed: true,
+      isCompleted: result?['isCompleted'] ?? false,
+      isCompletedInTime: result?['isCompletedInTime'] ?? false,
+      elapsedSeconds: _timerService.elapsedWorkoutSeconds,
+    );
+  }
+
+  Future<void> _saveWorkout({
+    required bool completed,
+    bool isCompleted = false,
+    bool isCompletedInTime = false,
+    int elapsedSeconds = 0,
+  }) async {
     final workout = Workout(
       id: const Uuid().v4(),
       date: DateTime.now(),
@@ -62,6 +92,9 @@ class _TimerScreenState extends State<TimerScreen> {
       restBetweenSets: widget.config.restBetweenSets,
       completed: completed,
       completedSets: completed ? widget.config.numberOfSets : _timerService.completedSets,
+      isCompleted: isCompleted,
+      isCompletedInTime: isCompletedInTime,
+      elapsedSeconds: elapsedSeconds,
     );
 
     // Save to local storage

--- a/lib/services/timer_service.dart
+++ b/lib/services/timer_service.dart
@@ -22,6 +22,8 @@ class TimerService extends ChangeNotifier {
   int _repsPerSet = 0;
   int _lastRep = 0;
   int _initialCountdownSeconds = 10;
+  int _elapsedWorkoutSeconds = 0;
+  bool _workoutStarted = false;
   final AudioService _audioService;
 
   TimerService({AudioService? audioService})
@@ -34,6 +36,7 @@ class TimerService extends ChangeNotifier {
   int get workSeconds => _workSeconds;
   int get restSeconds => _restSeconds;
   int get repsPerSet => _repsPerSet;
+  int get elapsedWorkoutSeconds => _elapsedWorkoutSeconds;
 
   int get currentRep {
     if (_state != TimerState.work || _repsPerSet <= 0) {
@@ -91,6 +94,10 @@ class TimerService extends ChangeNotifier {
     _state = TimerState.work;
     _currentSeconds = _workSeconds;
     _lastRep = 1; // Reset to first rep
+    // Mark workout as started on first work set (excludes countdown from elapsed time)
+    if (!_workoutStarted) {
+      _workoutStarted = true;
+    }
     // Play whistle to signal start of work
     _audioService.playWhistle();
     notifyListeners();
@@ -112,6 +119,11 @@ class TimerService extends ChangeNotifier {
   }
 
   void _tick() {
+    // Track elapsed time only after workout has started (excludes countdown)
+    if (_workoutStarted) {
+      _elapsedWorkoutSeconds++;
+    }
+
     if (_currentSeconds > 1) {
       _currentSeconds--;
       // Play countdown beep in last 3 seconds of initial countdown
@@ -186,6 +198,8 @@ class TimerService extends ChangeNotifier {
     _state = TimerState.idle;
     _currentSeconds = 0;
     _currentSet = 0;
+    _elapsedWorkoutSeconds = 0;
+    _workoutStarted = false;
     notifyListeners();
   }
 

--- a/test/models/workout_test.dart
+++ b/test/models/workout_test.dart
@@ -176,6 +176,158 @@ void main() {
         expect(defaultWorkout.completed, equals(false));
         expect(defaultWorkout.completedSets, equals(0));
       });
+
+      test('new questionnaire fields default to false and 0', () {
+        final defaultWorkout = Workout(
+          id: 'id',
+          date: DateTime.now(),
+          burpeeType: BurpeeType.militarySixCount,
+          repsPerSet: 10,
+          secondsPerSet: 20,
+          numberOfSets: 8,
+          restBetweenSets: 10,
+        );
+
+        expect(defaultWorkout.isCompleted, equals(false));
+        expect(defaultWorkout.isCompletedInTime, equals(false));
+        expect(defaultWorkout.elapsedSeconds, equals(0));
+      });
+    });
+
+    group('new questionnaire fields', () {
+      test('can create workout with questionnaire fields', () {
+        final workoutWithQuestionnaire = Workout(
+          id: 'test-id',
+          date: DateTime.now(),
+          burpeeType: BurpeeType.militarySixCount,
+          repsPerSet: 10,
+          secondsPerSet: 20,
+          numberOfSets: 8,
+          restBetweenSets: 10,
+          completed: true,
+          completedSets: 8,
+          isCompleted: true,
+          isCompletedInTime: true,
+          elapsedSeconds: 245,
+        );
+
+        expect(workoutWithQuestionnaire.isCompleted, equals(true));
+        expect(workoutWithQuestionnaire.isCompletedInTime, equals(true));
+        expect(workoutWithQuestionnaire.elapsedSeconds, equals(245));
+      });
+
+      test('copyWith updates questionnaire fields', () {
+        final copy = workout.copyWith(
+          isCompleted: true,
+          isCompletedInTime: false,
+          elapsedSeconds: 300,
+        );
+
+        expect(copy.isCompleted, equals(true));
+        expect(copy.isCompletedInTime, equals(false));
+        expect(copy.elapsedSeconds, equals(300));
+        expect(copy.id, equals(workout.id)); // Other fields unchanged
+      });
+
+      test('toJson includes questionnaire fields', () {
+        final workoutWithQuestionnaire = workout.copyWith(
+          isCompleted: true,
+          isCompletedInTime: true,
+          elapsedSeconds: 245,
+        );
+        final json = workoutWithQuestionnaire.toJson();
+
+        expect(json['isCompleted'], equals(true));
+        expect(json['isCompletedInTime'], equals(true));
+        expect(json['elapsedSeconds'], equals(245));
+      });
+
+      test('fromJson deserializes questionnaire fields', () {
+        final json = {
+          'id': 'json-id',
+          'date': '2024-02-20T14:00:00.000',
+          'burpeeType': 1,
+          'repsPerSet': 15,
+          'secondsPerSet': 30,
+          'numberOfSets': 5,
+          'restBetweenSets': 15,
+          'completed': true,
+          'completedSets': 5,
+          'isCompleted': true,
+          'isCompletedInTime': false,
+          'elapsedSeconds': 320,
+        };
+
+        final fromJson = Workout.fromJson(json);
+
+        expect(fromJson.isCompleted, equals(true));
+        expect(fromJson.isCompletedInTime, equals(false));
+        expect(fromJson.elapsedSeconds, equals(320));
+      });
+
+      test('round-trip serialization preserves questionnaire fields', () {
+        final workoutWithQuestionnaire = workout.copyWith(
+          isCompleted: true,
+          isCompletedInTime: true,
+          elapsedSeconds: 245,
+        );
+        final json = workoutWithQuestionnaire.toJson();
+        final restored = Workout.fromJson(json);
+
+        expect(restored.isCompleted, equals(true));
+        expect(restored.isCompletedInTime, equals(true));
+        expect(restored.elapsedSeconds, equals(245));
+      });
+    });
+
+    group('backward compatibility', () {
+      test('fromJson handles missing questionnaire fields with defaults', () {
+        // Old JSON format without new fields
+        final oldJson = {
+          'id': 'old-workout',
+          'date': '2024-01-01T12:00:00.000',
+          'burpeeType': 0,
+          'repsPerSet': 10,
+          'secondsPerSet': 20,
+          'numberOfSets': 8,
+          'restBetweenSets': 10,
+          'completed': true,
+          'completedSets': 8,
+        };
+
+        final fromOldJson = Workout.fromJson(oldJson);
+
+        // Should use default values for new fields
+        expect(fromOldJson.isCompleted, equals(false));
+        expect(fromOldJson.isCompletedInTime, equals(false));
+        expect(fromOldJson.elapsedSeconds, equals(0));
+        // Other fields should still work
+        expect(fromOldJson.id, equals('old-workout'));
+        expect(fromOldJson.completed, equals(true));
+      });
+
+      test('fromJson handles null questionnaire fields with defaults', () {
+        final jsonWithNulls = {
+          'id': 'null-fields',
+          'date': '2024-01-01T12:00:00.000',
+          'burpeeType': 0,
+          'repsPerSet': 10,
+          'secondsPerSet': 20,
+          'numberOfSets': 8,
+          'restBetweenSets': 10,
+          'completed': true,
+          'completedSets': 8,
+          'isCompleted': null,
+          'isCompletedInTime': null,
+          'elapsedSeconds': null,
+        };
+
+        final fromJson = Workout.fromJson(jsonWithNulls);
+
+        expect(fromJson.isCompleted, equals(false));
+        expect(fromJson.isCompletedInTime, equals(false));
+        expect(fromJson.elapsedSeconds, equals(0));
+      });
     });
   });
 }

--- a/test/screens/post_workout_questionnaire_screen_test.dart
+++ b/test/screens/post_workout_questionnaire_screen_test.dart
@@ -1,0 +1,314 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:burpeebata/screens/post_workout_questionnaire_screen.dart';
+import 'package:burpeebata/models/workout_config.dart';
+import 'package:burpeebata/models/burpee_type.dart';
+
+void main() {
+  group('PostWorkoutQuestionnaireScreen', () {
+    const testConfig = WorkoutConfig(
+      burpeeType: BurpeeType.militarySixCount,
+      repsPerSet: 10,
+      secondsPerSet: 20,
+      numberOfSets: 8,
+      restBetweenSets: 10,
+    );
+
+    Widget createTestWidget({
+      WorkoutConfig config = testConfig,
+      int elapsedSeconds = 245,
+    }) {
+      return MaterialApp(
+        home: PostWorkoutQuestionnaireScreen(
+          config: config,
+          elapsedSeconds: elapsedSeconds,
+        ),
+      );
+    }
+
+    group('initial state', () {
+      testWidgets('displays workout complete title', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Workout Complete!'), findsOneWidget);
+      });
+
+      testWidgets('displays congratulatory message', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Great job!'), findsOneWidget);
+      });
+
+      testWidgets('displays question 1', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(
+          find.text('Did you complete all the sets?'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('does not display question 2 initially', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(
+          find.text('Did you complete the workout in less than 5 minutes?'),
+          findsNothing,
+        );
+      });
+
+      testWidgets('submit button is disabled initially', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        final submitButton = tester.widget<ElevatedButton>(
+          find.widgetWithText(ElevatedButton, 'SUBMIT'),
+        );
+
+        expect(submitButton.onPressed, isNull);
+      });
+    });
+
+    group('question 1 interaction', () {
+      testWidgets('can select YES for question 1', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.tap(find.text('YES').first);
+        await tester.pump();
+
+        // Question 2 should now appear
+        expect(
+          find.text('Did you complete the workout in less than 5 minutes?'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('can select NO for question 1', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.tap(find.text('NO').first);
+        await tester.pump();
+
+        // Question 2 should NOT appear
+        expect(
+          find.text('Did you complete the workout in less than 5 minutes?'),
+          findsNothing,
+        );
+      });
+
+      testWidgets('submit button becomes enabled after answering Q1',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.tap(find.text('YES').first);
+        await tester.pump();
+
+        final submitButton = tester.widget<ElevatedButton>(
+          find.widgetWithText(ElevatedButton, 'SUBMIT'),
+        );
+
+        expect(submitButton.onPressed, isNotNull);
+      });
+    });
+
+    group('question 2 conditional display', () {
+      testWidgets('shows question 2 when Q1 is YES', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.tap(find.text('YES').first);
+        await tester.pump();
+
+        expect(
+          find.text('Did you complete the workout in less than 5 minutes?'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('hides question 2 when Q1 is NO', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // First select YES to show Q2
+        await tester.tap(find.text('YES').first);
+        await tester.pump();
+
+        expect(
+          find.text('Did you complete the workout in less than 5 minutes?'),
+          findsOneWidget,
+        );
+
+        // Then select NO to hide Q2
+        await tester.tap(find.text('NO').first);
+        await tester.pump();
+
+        expect(
+          find.text('Did you complete the workout in less than 5 minutes?'),
+          findsNothing,
+        );
+      });
+
+      testWidgets('displays elapsed time in question 2', (tester) async {
+        await tester.pumpWidget(createTestWidget(elapsedSeconds: 245));
+
+        await tester.tap(find.text('YES').first);
+        await tester.pump();
+
+        // 245 seconds = 4 minutes 5 seconds = "4:05"
+        expect(find.text('Your time: 4:05'), findsOneWidget);
+      });
+
+      testWidgets('formats elapsed time correctly for whole minutes',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget(elapsedSeconds: 180));
+
+        await tester.tap(find.text('YES').first);
+        await tester.pump();
+
+        // 180 seconds = 3 minutes = "3:00"
+        expect(find.text('Your time: 3:00'), findsOneWidget);
+      });
+
+      testWidgets('formats elapsed time correctly for single digit seconds',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget(elapsedSeconds: 305));
+
+        await tester.tap(find.text('YES').first);
+        await tester.pump();
+
+        // 305 seconds = 5 minutes 5 seconds = "5:05"
+        expect(find.text('Your time: 5:05'), findsOneWidget);
+      });
+    });
+
+    group('question 2 interaction', () {
+      testWidgets('can select YES for question 2', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Answer Q1 to show Q2
+        await tester.tap(find.text('YES').first);
+        await tester.pump();
+
+        // Answer Q2
+        await tester.tap(find.text('YES').last);
+        await tester.pump();
+
+        // Should remain on screen
+        expect(find.text('Workout Complete!'), findsOneWidget);
+      });
+
+      testWidgets('can select NO for question 2', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Answer Q1 to show Q2
+        await tester.tap(find.text('YES').first);
+        await tester.pump();
+
+        // Answer Q2
+        await tester.tap(find.text('NO').last);
+        await tester.pump();
+
+        // Should remain on screen
+        expect(find.text('Workout Complete!'), findsOneWidget);
+      });
+    });
+
+    group('submit behavior', () {
+      testWidgets('submitting with Q1=YES, Q2=YES completes successfully',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Answer Q1
+        await tester.tap(find.text('YES').first);
+        await tester.pump();
+
+        // Answer Q2
+        await tester.tap(find.text('YES').last);
+        await tester.pump();
+
+        // Submit button should be enabled
+        final submitButton = tester.widget<ElevatedButton>(
+          find.widgetWithText(ElevatedButton, 'SUBMIT'),
+        );
+        expect(submitButton.onPressed, isNotNull);
+
+        // Tap submit (navigation happens)
+        await tester.tap(find.text('SUBMIT'));
+        await tester.pumpAndSettle();
+      });
+
+      testWidgets('submitting with Q1=NO hides Q2', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Answer Q1 as NO
+        await tester.tap(find.text('NO').first);
+        await tester.pump();
+
+        // Q2 should not appear
+        expect(
+          find.text('Did you complete the workout in less than 5 minutes?'),
+          findsNothing,
+        );
+
+        // Submit button should be enabled
+        final submitButton = tester.widget<ElevatedButton>(
+          find.widgetWithText(ElevatedButton, 'SUBMIT'),
+        );
+        expect(submitButton.onPressed, isNotNull);
+      });
+    });
+
+    group('back button handling', () {
+      testWidgets('prevents default back navigation', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // PopScope with canPop: false prevents navigation
+        expect(find.text('Workout Complete!'), findsOneWidget);
+      });
+    });
+
+    group('button styling', () {
+      testWidgets('buttons respond to selection', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Select YES
+        await tester.tap(find.text('YES').first);
+        await tester.pump();
+
+        // Q2 should appear as a result of selection
+        expect(
+          find.text('Did you complete the workout in less than 5 minutes?'),
+          findsOneWidget,
+        );
+
+        // Select NO instead
+        await tester.tap(find.text('NO').first);
+        await tester.pump();
+
+        // Q2 should disappear
+        expect(
+          find.text('Did you complete the workout in less than 5 minutes?'),
+          findsNothing,
+        );
+      });
+    });
+
+    group('edge cases', () {
+      testWidgets('handles 0 elapsed seconds', (tester) async {
+        await tester.pumpWidget(createTestWidget(elapsedSeconds: 0));
+
+        await tester.tap(find.text('YES').first);
+        await tester.pump();
+
+        expect(find.text('Your time: 0:00'), findsOneWidget);
+      });
+
+      testWidgets('handles very large elapsed seconds', (tester) async {
+        await tester.pumpWidget(createTestWidget(elapsedSeconds: 999));
+
+        await tester.tap(find.text('YES').first);
+        await tester.pump();
+
+        // 999 seconds = 16 minutes 39 seconds
+        expect(find.text('Your time: 16:39'), findsOneWidget);
+      });
+    });
+  });
+}

--- a/test/services/timer_service_test.dart
+++ b/test/services/timer_service_test.dart
@@ -513,6 +513,168 @@ void main() {
         expect(notificationCount, equals(1));
       });
     });
+
+    group('elapsed time tracking', () {
+      test('starts at 0', () {
+        expect(timerService.elapsedWorkoutSeconds, equals(0));
+      });
+
+      test('remains 0 during countdown', () {
+        fakeAsync((async) {
+          const config = WorkoutConfig(initialCountdown: 5);
+          timerService.startWorkout(config);
+          async.flushMicrotasks();
+
+          // Elapse 4 seconds of countdown
+          async.elapse(const Duration(seconds: 4));
+
+          // Still in countdown state
+          expect(timerService.state, equals(TimerState.countdown));
+          // Elapsed time should still be 0 (countdown excluded)
+          expect(timerService.elapsedWorkoutSeconds, equals(0));
+        });
+      });
+
+      test('starts counting after countdown completes', () {
+        fakeAsync((async) {
+          const config = WorkoutConfig(
+            initialCountdown: 3,
+            secondsPerSet: 20,
+            numberOfSets: 1,
+          );
+          timerService.startWorkout(config);
+          async.flushMicrotasks();
+
+          // Elapse countdown (3s)
+          async.elapse(const Duration(seconds: 3));
+
+          // Now in work state
+          expect(timerService.state, equals(TimerState.work));
+          // Elapsed should still be 0 at exact transition
+          expect(timerService.elapsedWorkoutSeconds, equals(0));
+
+          // Elapse 1 more second of work
+          async.elapse(const Duration(seconds: 1));
+
+          // Now elapsed should be 1
+          expect(timerService.elapsedWorkoutSeconds, equals(1));
+        });
+      });
+
+      test('continues counting through work periods', () {
+        fakeAsync((async) {
+          const config = WorkoutConfig(
+            initialCountdown: 3,
+            secondsPerSet: 10,
+            numberOfSets: 1,
+            restBetweenSets: 0,
+          );
+          timerService.startWorkout(config);
+          async.flushMicrotasks();
+
+          // Elapse countdown + 5 seconds of work
+          async.elapse(const Duration(seconds: 8));
+
+          expect(timerService.state, equals(TimerState.work));
+          expect(timerService.elapsedWorkoutSeconds, equals(5));
+        });
+      });
+
+      test('continues counting through rest periods', () {
+        fakeAsync((async) {
+          const config = WorkoutConfig(
+            initialCountdown: 3,
+            secondsPerSet: 5,
+            numberOfSets: 2,
+            restBetweenSets: 4,
+          );
+          timerService.startWorkout(config);
+          async.flushMicrotasks();
+
+          // Elapse countdown (3s) + first work period (5s) + 2 seconds of rest
+          async.elapse(const Duration(seconds: 10));
+
+          expect(timerService.state, equals(TimerState.rest));
+          // Should have counted: 5s work + 2s rest = 7s total
+          expect(timerService.elapsedWorkoutSeconds, equals(7));
+        });
+      });
+
+      test('tracks complete workout with multiple sets', () {
+        fakeAsync((async) {
+          const config = WorkoutConfig(
+            initialCountdown: 3,
+            secondsPerSet: 10,
+            numberOfSets: 3,
+            restBetweenSets: 5,
+          );
+          timerService.startWorkout(config);
+          async.flushMicrotasks();
+
+          // Total workout time (excluding countdown):
+          // 3 work periods * 10s = 30s
+          // 2 rest periods * 5s = 10s
+          // Total = 40s
+
+          // Elapse countdown (3s) + full workout (40s)
+          async.elapse(const Duration(seconds: 43));
+
+          expect(timerService.state, equals(TimerState.finished));
+          expect(timerService.elapsedWorkoutSeconds, equals(40));
+        });
+      });
+
+      test('resets to 0 on stop', () {
+        fakeAsync((async) {
+          const config = WorkoutConfig(
+            initialCountdown: 3,
+            secondsPerSet: 20,
+            numberOfSets: 1,
+          );
+          timerService.startWorkout(config);
+          async.flushMicrotasks();
+
+          // Elapse some time
+          async.elapse(const Duration(seconds: 10));
+
+          // Should have some elapsed time
+          expect(timerService.elapsedWorkoutSeconds, greaterThan(0));
+
+          // Stop the workout
+          timerService.stop();
+
+          // Elapsed time should reset
+          expect(timerService.elapsedWorkoutSeconds, equals(0));
+        });
+      });
+
+      test('does not count time during pause', () {
+        fakeAsync((async) {
+          const config = WorkoutConfig(
+            initialCountdown: 3,
+            secondsPerSet: 20,
+            numberOfSets: 1,
+          );
+          timerService.startWorkout(config);
+          async.flushMicrotasks();
+
+          // Elapse countdown + 5 seconds of work
+          async.elapse(const Duration(seconds: 8));
+
+          final elapsedBeforePause = timerService.elapsedWorkoutSeconds;
+          expect(elapsedBeforePause, equals(5));
+
+          // Pause the timer
+          timerService.pause();
+
+          // Elapse more time while paused
+          async.elapse(const Duration(seconds: 10));
+
+          // Elapsed time should not change during pause
+          expect(timerService.elapsedWorkoutSeconds, equals(elapsedBeforePause));
+        });
+      });
+    });
   });
 
   group('TimerState enum', () {


### PR DESCRIPTION
  Closes #26

  ## Summary

  Adds a post-workout questionnaire that captures user confirmation of workout completion and timing. This addresses the issue where users who are exhausted mid-workout might not interrupt the timer, leading to inaccurate workout data.

  ## Motivation

  Previously, the app assumed a workout was completed unless explicitly interrupted by the user. However, an exhausted user might let the timer finish without actually completing all sets, resulting in misleading workout records.

  ## Solution

  Implemented a two-question post-workout questionnaire that appears after the timer finishes:

  1. **"Did you complete all the sets?"** (Yes/No)
  2. **"Did you complete the workout in less than 5 minutes?"** (Yes/No - only shown if Q1=Yes)

  The app now tracks:
  - User-confirmed completion status (`isCompleted`)
  - Whether workout was completed within 5 minutes (`isCompletedInTime`)
  - Actual elapsed time excluding countdown (`elapsedSeconds`)

  If the user dismisses the questionnaire without answering, the workout is saved with default values (`false`, `false`, `0`) to prevent data loss.

  ## Changes

  ### Model Updates
  **`lib/models/workout.dart`**
  - Added 3 new fields: `isCompleted`, `isCompletedInTime`, `elapsedSeconds`
  - Updated serialization methods (`toJson`, `fromJson`) with backward compatibility
  - Updated `copyWith()` to support new fields

  ### Service Updates
  **`lib/services/timer_service.dart`**
  - Added elapsed time tracking that starts after countdown phase
  - Tracks all work and rest periods
  - Exposed via `elapsedWorkoutSeconds` getter
  - Properly resets on `stop()`

  ### New Screen
  **`lib/screens/post_workout_questionnaire_screen.dart`**
  - Created new questionnaire UI with conditional Q2 display
  - Shows actual elapsed time to user (formatted as MM:SS)
  - Scrollable layout to prevent overflow on smaller screens
  - Uses `PopScope` to handle back navigation
  - Returns default values if dismissed

  ### Integration
  **`lib/screens/timer_screen.dart`**
  - Modified workout completion flow to show questionnaire
  - Added `_showPostWorkoutQuestionnaire()` method
  - Updated `_saveWorkout()` signature to accept new fields
  - Workout data now includes questionnaire responses

  ## Testing

  ### Unit Tests
  - ✅ **Workout Model** (23 tests)
    - Default values
    - Serialization with new fields
    - Backward compatibility with old JSON
    - `copyWith` functionality

  - ✅ **TimerService** (49 tests)
    - Elapsed time tracking in all states
    - Countdown exclusion
    - Reset behavior
    - Pause handling

  ### Widget Tests
  - ✅ **PostWorkoutQuestionnaireScreen** (21 tests)
    - UI rendering and interaction
    - Conditional Q2 display logic
    - Time formatting
    - Submit and navigation behavior

  All tests passing: **93/93** ✓

  ## Backward Compatibility

  ✅ **Fully backward compatible**
  - Old workouts deserialize correctly with null-coalescing defaults
  - No database migration required (Firestore accepts new fields automatically)
  - Existing functionality unchanged

  ## Code Quality

  - ✅ No analyzer issues in new code
  - ✅ Fixed deprecation warnings (`WillPopScope` → `PopScope`)
  - ✅ Follows existing codebase patterns
  - ✅ Comprehensive test coverage

  ## Demo

  After completing a workout:
  1. Questionnaire appears with Q1: "Did you complete all the sets?"
  2. If user selects "Yes", Q2 appears: "Did you complete in less than 5 minutes?"
  3. Display shows actual elapsed time (e.g., "Your time: 4:05")
  4. User submits responses, workout saves with enriched data
  5. If user dismisses questionnaire, workout saves with safe defaults

  ## Checklist

  - [x] Implementation complete
  - [x] Tests written and passing
  - [x] Code analyzed (no new issues)
  - [x] Backward compatibility verified
  - [x] Documentation updated (CLAUDE.md)

