### PR TITLE
DND enabled

### DIFF
--- a/ISSUE_53.md
+++ b/ISSUE_53.md
@@ -1,0 +1,29 @@
+title:	Handle very short rests
+state:	OPEN
+author:	clockworkpc
+labels:	
+comments:	0
+assignees:	
+projects:	
+milestone:	
+number:	53
+--
+WHEN restSeconds = 3 seconds
+AND workSeconds = x seconds
+THEN play both startWorkout and end-of-rest countdown SFX simultaneously.
+
+WHEN restSeconds < 3 seconds
+DO NOT play end-of-workout SFX
+
+WHEN restSeconds = 2 seconds
+AND workSeconds = x seconds
+THEN start 3-second end-of-rest countdown at x-1 second mark of workSeconds.
+
+WHEN restSeconds = 1 second
+AND workSeconds = x seconds
+THEN start 3-second end-of-rest countdown at x-2 second mark of workSeconds.
+
+WHEN restSeconds = 0 seconds
+AND workSeconds = x seconds
+THEN start 3-second end-of-rest countdown at x-3 second mark of workSeconds.
+

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,19 @@
+## Summary
+
+- Add Do Not Disturb mode support during workouts (Android only)
+- New `DndService` handles enabling/disabling DND with permission management
+- Toggle button in home screen app bar to enable/disable the feature
+- DND automatically enables when workout starts and restores previous state when workout ends
+- Persisted user preference via `StorageService`
+
+## Test plan
+
+- [ ] Verify DND toggle appears on Android devices
+- [ ] Verify DND toggle does NOT appear on iOS/web
+- [ ] Test permission request flow when enabling DND for the first time
+- [ ] Confirm DND activates when starting a workout (with setting enabled)
+- [ ] Confirm DND restores to previous state when workout ends
+- [ ] Verify preference persists across app restarts
+- [ ] Run `make test` to verify all tests pass
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.burpeebata.app">
+
+    <!-- Required for Do Not Disturb mode control during workouts -->
+    <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
+
    <application
         android:label="burpeebata"
         android:name="${applicationName}"

--- a/diff.txt
+++ b/diff.txt
@@ -1,0 +1,608 @@
+diff --git c/.gitignore w/.gitignore
+index bf7293f..7b8eecd 100644
+--- c/.gitignore
++++ w/.gitignore
+@@ -44,6 +44,9 @@ app.*.map.json
+ /android/app/release
+ .gradle
+ 
++# Java heap dumps
++*.hprof
++
+ archive/
+ 
+ # Node.js related (for import scripts)
+diff --git c/CLAUDE.md w/CLAUDE.md
+index 12082c9..6a0e3f3 100644
+--- c/CLAUDE.md
++++ w/CLAUDE.md
+@@ -11,9 +11,12 @@ BurpeeBata is a Flutter application - a tabata timer specifically designed for b
+ All commands run through Docker Compose via Makefile:
+ 
+ ```bash
+-# Start development environment
++# Start development environment (uses dev Firebase)
+ make up
+ 
++# Start with production Firebase
++FLUTTER_ENV=prod make up
++
+ # Build and start
+ make up-build
+ 
+@@ -26,46 +29,65 @@ docker compose exec flutter flutter test test/path/to/test_file.dart
+ # Generate mocks (for mockito)
+ make mocks
+ 
+-# Build release APK
++# Build production APK (uses production Firebase)
+ make apk
+ 
++# Build development APK (uses dev Firebase)
++make apk-dev
++
++# Build production web app
++make build-web
++
++# Build development web app
++make build-web-dev
++
++# Install dependencies
++make pub-get
++
+ # View logs
+ make logs
+ 
+ # Check Flutter environment
+ make doctor
++
++# Run linting
++docker compose exec flutter flutter analyze
+ ```
+ 
+ ## Code Architecture
+ 
+ ### Directory Structure
+ - `lib/` - Main application code
+-  - `main.dart` - App entry point with Firebase initialization and Provider setup
++  - `main.dart` - App entry point with dual Firebase config and Provider setup
++  - `firebase_options.dart` - Development Firebase configuration
++  - `firebase_options_prod.dart` - Production Firebase configuration
++  - `theme/` - App theme and design system
+   - `screens/` - UI screens
+     - Authentication: LoginScreen, SignupScreen, AuthWrapper
+     - Main: HomeScreen, TimerScreen, HistoryScreen, ProfileScreen
+-    - Workouts: SavedWorkoutsScreen, WorkoutBuilderScreen
++    - Workouts: SavedWorkoutsScreen, WorkoutBuilderScreen, PostWorkoutQuestionnaireScreen
+   - `models/` - Data models
+     - Workout data: Workout, WorkoutConfig, BurpeeType, WorkoutTemplate
+     - User data: UserProfile (with optional fields)
+   - `services/` - Business logic
+-    - Workout: TimerService, StorageService, AudioService
++    - Workout: TimerService, StorageService (local), WorkoutService (Firestore), AudioService
+     - User: AuthService (Firebase Auth), UserService (Firestore)
+   - `providers/` - State management (Provider pattern)
+     - AuthProvider - Authentication state and user profile
+ - `test/` - Test files mirror lib structure
+ - `assets/audio/` - Audio files for workout cues
++- `scripts/` - Utility scripts for data migration and imports
+ 
+ ### Key Dependencies
+ 
+ **Authentication & Data:**
+ - `firebase_core` - Firebase initialization
+ - `firebase_auth` - User authentication (email/password, anonymous)
+-- `cloud_firestore` - User profile storage in cloud
++- `cloud_firestore` - User profile and workout storage in cloud
+ - `provider` - State management for authentication
+ 
+ **Workout Features:**
+-- `shared_preferences` - Local storage for workout history
++- `shared_preferences` - Local storage for workout history (offline-first)
+ - `audioplayers` - Audio playback for timer cues
+ - `wakelock_plus` - Keep screen awake during workout
+ - `uuid` - Unique ID generation
+@@ -74,6 +96,27 @@ make doctor
+ **Development:**
+ - `mockito` + `build_runner` - Test mocking
+ - `flutter_lints` - Linting rules
++- `fake_cloud_firestore` - Mock Firestore for testing
++- `firebase_auth_mocks` - Mock Firebase Auth for testing
++- `fake_async` - Async testing utilities
++
++## Dual Firebase Environment
++
++The app supports separate development and production Firebase projects:
++
++**Configuration:** `lib/main.dart`
++- Build flag `PRODUCTION` determines which Firebase project to use
++- Development (default): Uses `firebase_options.dart` (burpeebata-dev)
++- Production: Uses `firebase_options_prod.dart` (burpeebata) when `--dart-define=PRODUCTION=true`
++
++**Usage:**
++- Development builds: `make up`, `make apk-dev`, `make build-web-dev`
++- Production builds: `make apk`, `make build-web`, or `FLUTTER_ENV=prod make up`
++
++**Benefits:**
++- Test features without affecting production data
++- Separate analytics and error tracking
++- Safe iteration during development
+ 
+ ## Testing
+ 
+@@ -84,6 +127,8 @@ To regenerate mocks after adding new mock annotations:
+ make mocks
+ ```
+ 
++Test files are located in `test/` and mirror the structure of `lib/`.
++
+ ## Authentication & User Profiles
+ 
+ BurpeeBata uses Firebase for authentication and user data storage.
+@@ -113,32 +158,54 @@ See `APP_STORE_REVIEWER_ACCESS.md` for credentials and access instructions.
+ 
+ ## Workout Storage Architecture
+ 
+-### Current Implementation (Local Only)
+-**File**: `lib/services/storage_service.dart`
++The app uses an **offline-first** architecture with dual storage:
+ 
+-Workouts are currently stored in **SharedPreferences** (device-local only):
+-- **Key**: `'workouts'` - JSON-encoded list of completed/partial workouts
+-- **Key**: `'workout_templates'` - JSON-encoded list of saved templates
+-- **Limitation**: Data is per-device only, not synced across devices
++### Storage Services
+ 
+-**Operations:**
+-- `saveWorkout()` - Adds workout to local storage
+-- `getWorkouts()` - Retrieves all workouts (sorted newest first)
+-- `deleteWorkout()` - Removes specific workout
+-- `clearAllWorkouts()` - Wipes all workout history
++**1. StorageService** (`lib/services/storage_service.dart`)
++- Local storage using SharedPreferences
++- Primary source of truth for data safety
++- Works offline
++- **Keys:**
++  - `'workouts'` - JSON-encoded list of completed/partial workouts
++  - `'workout_templates'` - JSON-encoded list of saved templates
++
++**2. WorkoutService** (`lib/services/workout_service.dart`)
++- Cloud storage using Firestore
++- Syncs data across devices for authenticated users
++- Subcollection structure: `users/{userId}/workouts/{workoutId}`
++- User isolation enforced by security rules
++- **Methods:**
++  - `saveWorkout()` - Save/update workout
++  - `getWorkouts()` - Retrieve all workouts (sorted newest first)
++  - `workoutsStream()` - Real-time updates
++  - `deleteWorkout()` - Delete specific workout
++  - `clearAllWorkouts()` - Delete all workouts
++  - `getWorkoutsInRange()` - Query by date range
++  - `getRecentWorkouts()` - Get N most recent
+ 
+ ### Workout Data Flow
+ 
+-**Workout Execution**: `lib/screens/timer_screen.dart`
++**Workout Execution:** `lib/screens/timer_screen.dart`
+ 1. User starts workout with `WorkoutConfig`
+ 2. `TimerService` manages countdown and state
+ 3. Completion triggers save via `_saveWorkout()`:
+    - Normal completion → `completed: true`
+    - Early end → `completed: false` with partial sets
+    - Back navigation → Shows dialog, saves on confirm
+-4. Data saved to SharedPreferences only
++4. **Dual save:**
++   - Saves to SharedPreferences first (ensures data never lost)
++   - Syncs to Firestore for authenticated non-anonymous users
++   - Graceful error handling - logs errors but doesn't fail
+ 
+-**Workout Model**: `lib/models/workout.dart`
++**Workout Display:** `lib/screens/history_screen.dart`
++- **Authenticated non-anonymous users:** Loads from Firestore with local fallback
++- **Anonymous/guest users:** Uses local storage only
++- Delete operations sync to both local and Firestore
++- Shows: date, time, burpee type, sets, reps, completion status
++- Actions: Share (via `share_plus`), Delete (with confirmation)
++
++**Workout Model:** `lib/models/workout.dart`
+ ```dart
+ class Workout {
+   final String id;              // UUID v4
+@@ -150,6 +217,9 @@ class Workout {
+   final int restBetweenSets;
+   final bool completed;         // true if all sets finished
+   final int completedSets;      // actual sets completed
++  final bool isCompleted;
++  final bool isCompletedInTime;
++  final int elapsedSeconds;
+ 
+   // Calculated properties
+   int get totalReps => repsPerSet * completedSets;
+@@ -157,22 +227,15 @@ class Workout {
+ }
+ ```
+ 
+-**Workout Display**: `lib/screens/history_screen.dart`
+-- Loads from `StorageService.getWorkouts()`
+-- Shows: date, time, burpee type, sets, reps, completion status
+-- Actions: Share (via `share_plus`), Delete (with confirmation)
++### Firestore Data Structure
+ 
+-### Future: Cloud Storage (Not Yet Implemented)
+-
+-To sync workouts to Firestore (following the UserService pattern):
+-
+-**Proposed Structure**:
+ ```
+ Firestore
+ └── users/{userId}
+     ├── (user profile fields)
+     └── workouts (subcollection)
+         └── {workoutId}
++            ├── id
+             ├── date
+             ├── burpeeType
+             ├── repsPerSet
+@@ -180,15 +243,51 @@ Firestore
+             ├── numberOfSets
+             ├── restBetweenSets
+             ├── completed
+-            └── completedSets
++            ├── completedSets
++            ├── isCompleted
++            ├── isCompletedInTime
++            └── elapsedSeconds
+ ```
+ 
+-**Implementation would require**:
+-1. New `WorkoutService` (similar to `lib/services/user_service.dart`)
+-2. Firestore security rules to isolate user workouts
+-3. Modifications to `TimerScreen` to sync after local save
+-4. Modifications to `HistoryScreen` to load from Firestore when authenticated
+-5. Offline-first approach with local cache
++### Firestore Security Rules
++
++File: `firestore.rules`
++
++```javascript
++rules_version = '2';
++service cloud.firestore {
++  match /databases/{database}/documents {
++    match /users/{userId} {
++      allow read, write: if request.auth != null && request.auth.uid == userId;
++
++      match /workouts/{workoutId} {
++        allow read, write: if request.auth != null && request.auth.uid == userId;
++      }
++    }
++  }
++}
++```
++
++Deploy rules: `firebase deploy --only firestore:rules`
++
++### Data Migration
++
++**Import Scripts:** Import workouts from CSV to Firestore
++- `import_workouts.sh` - Bash implementation (requires gcloud)
++- `import_workouts.py` - Python implementation
++- `import_workouts.js` - Node.js implementation
++
++**Usage:**
++```bash
++./import_workouts.sh <user_id> <csv_file>
++```
++
++## Audio System
++
++**AudioService** (`lib/services/audio_service.dart`)
++- Manages workout audio cues using `audioplayers` package
++- Audio files located in `assets/audio/`
++- Cues include: countdown beeps, whistles, boxing bell, ping
+ 
+ ## Linting
+ 
+@@ -196,3 +295,11 @@ Uses `flutter_lints` package. Run analysis with:
+ ```bash
+ docker compose exec flutter flutter analyze
+ ```
++
++## Additional Documentation
++
++- `FIREBASE_SETUP.md` - Complete Firebase configuration guide
++- `APP_STORE_REVIEWER_ACCESS.md` - Credentials and access for app store reviewers
++- `FIRESTORE_SECURITY_RULES.md` - Detailed security rules documentation
++- `IMPLEMENTATION_SUMMARY.md` - Workout cloud storage implementation details
++- `DEPLOYMENT.md` - Deployment instructions and procedures
+diff --git c/Makefile w/Makefile
+index ee98d2d..e088a4e 100644
+--- c/Makefile
++++ w/Makefile
+@@ -35,6 +35,8 @@ doctor:
+ 	docker compose exec flutter flutter doctor
+ 
+ apk:
++	@echo "Incrementing version..."
++	@./scripts/increment_version.sh
+ 	@echo "Building PRODUCTION APK with production Firebase (burpeebata)..."
+ 	docker compose exec flutter flutter build apk --release --dart-define=PRODUCTION=true --verbose
+ 
+diff --git c/android/gradle.properties w/android/gradle.properties
+index 589b8ec..8b75433 100644
+--- c/android/gradle.properties
++++ w/android/gradle.properties
+@@ -1,4 +1,4 @@
+-org.gradle.jvmargs=-Xmx4096M -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
++org.gradle.jvmargs=-Xmx4096M -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError
+ android.useAndroidX=true
+ android.enableJetifier=true
+ org.gradle.caching=true
+diff --git c/assets/audio/boxing_bell.mp3 w/assets/audio/boxing_bell.mp3
+deleted file mode 100644
+index dfc5d97..0000000
+Binary files c/assets/audio/boxing_bell.mp3 and /dev/null differ
+diff --git c/assets/audio/countdown_beep.mp3 w/assets/audio/countdown_beep.mp3
+deleted file mode 100644
+index 77a27f7..0000000
+Binary files c/assets/audio/countdown_beep.mp3 and /dev/null differ
+diff --git c/assets/audio/end_of_rest.wav w/assets/audio/end_of_rest.wav
+new file mode 100644
+index 0000000..17f8ecd
+Binary files /dev/null and w/assets/audio/end_of_rest.wav differ
+diff --git c/assets/audio/end_of_rest_with_pulses.wav w/assets/audio/end_of_rest_with_pulses.wav
+new file mode 100644
+index 0000000..2ef4490
+Binary files /dev/null and w/assets/audio/end_of_rest_with_pulses.wav differ
+diff --git c/assets/audio/end_of_set.wav w/assets/audio/end_of_set.wav
+new file mode 100644
+index 0000000..3c6c6ca
+Binary files /dev/null and w/assets/audio/end_of_set.wav differ
+diff --git c/assets/audio/end_of_workout.wav w/assets/audio/end_of_workout.wav
+new file mode 100644
+index 0000000..baecd62
+Binary files /dev/null and w/assets/audio/end_of_workout.wav differ
+diff --git c/assets/audio/last_rep_pulse.wav w/assets/audio/last_rep_pulse.wav
+new file mode 100644
+index 0000000..e41c2ca
+Binary files /dev/null and w/assets/audio/last_rep_pulse.wav differ
+diff --git c/assets/audio/ping.mp3 w/assets/audio/ping.mp3
+deleted file mode 100644
+index 6b11b45..0000000
+Binary files c/assets/audio/ping.mp3 and /dev/null differ
+diff --git c/assets/audio/rep_pulse.wav w/assets/audio/rep_pulse.wav
+new file mode 100644
+index 0000000..c961bbf
+Binary files /dev/null and w/assets/audio/rep_pulse.wav differ
+diff --git c/assets/audio/start_set_whistle.wav w/assets/audio/start_set_whistle.wav
+new file mode 100644
+index 0000000..83c490f
+Binary files /dev/null and w/assets/audio/start_set_whistle.wav differ
+diff --git c/assets/audio/whistle.mp3 w/assets/audio/whistle.mp3
+deleted file mode 100644
+index 500de1b..0000000
+Binary files c/assets/audio/whistle.mp3 and /dev/null differ
+diff --git c/lib/screens/home_screen.dart w/lib/screens/home_screen.dart
+index 41ef2db..afd4f03 100644
+--- c/lib/screens/home_screen.dart
++++ w/lib/screens/home_screen.dart
+@@ -148,7 +148,7 @@ class _HomeScreenState extends State<HomeScreen> {
+           child: Align(
+             alignment: Alignment.topLeft,
+             child: Text(
+-              'v1.1.0',
++              'v1.2.0',
+               style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                     color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+                   ),
+diff --git c/lib/services/audio_service.dart w/lib/services/audio_service.dart
+index 5df81f4..673b642 100644
+--- c/lib/services/audio_service.dart
++++ w/lib/services/audio_service.dart
+@@ -10,6 +10,7 @@ class AudioService {
+   final AudioPlayer _bellPlayer = AudioPlayer();
+   final AudioPlayer _pingPlayer = AudioPlayer();
+   final AudioPlayer _victoryPlayer = AudioPlayer();
++  final AudioPlayer _endOfRestPlayer = AudioPlayer();
+ 
+   bool _isInitialized = false;
+ 
+@@ -22,25 +23,32 @@ class AudioService {
+     await _bellPlayer.setReleaseMode(ReleaseMode.stop);
+     await _pingPlayer.setReleaseMode(ReleaseMode.stop);
+     await _victoryPlayer.setReleaseMode(ReleaseMode.stop);
++    await _endOfRestPlayer.setReleaseMode(ReleaseMode.stop);
+ 
+     _isInitialized = true;
+   }
+ 
+   /// Play countdown beep with escalating pitch
+   /// Design System v2: Rising pitch creates urgency
++  /// Uses last_rep_pulse.wav for final second, rep_pulse.wav for earlier seconds
+   Future<void> playCountdownBeep({int secondsRemaining = 3}) async {
+     await _beepPlayer.stop();
+ 
+-    // Escalate pitch based on urgency (3s = 1.0x, 2s = 1.1x, 1s = 1.2x)
++    // Use distinct sound for last second, regular pulse for earlier seconds
++    final audioFile = secondsRemaining == 1
++        ? 'audio/last_rep_pulse.wav'
++        : 'audio/rep_pulse.wav';
++
++    // Slight pitch escalation for urgency
+     final playbackRate = switch (secondsRemaining) {
+       3 => 1.0,
+-      2 => 1.1,
+-      1 => 1.2,
++      2 => 1.05,
++      1 => 1.1,
+       _ => 1.0,
+     };
+ 
+     await _beepPlayer.setPlaybackRate(playbackRate);
+-    await _beepPlayer.play(AssetSource('audio/countdown_beep.mp3'));
++    await _beepPlayer.play(AssetSource(audioFile));
+   }
+ 
+   /// Work start: Sharp, high-urgency signal
+@@ -48,7 +56,7 @@ class AudioService {
+   Future<void> playWorkStart() async {
+     await _whistlePlayer.stop();
+     await _whistlePlayer.setPlaybackRate(1.0);
+-    await _whistlePlayer.play(AssetSource('audio/whistle.mp3'));
++    await _whistlePlayer.play(AssetSource('audio/start_set_whistle.wav'));
+   }
+ 
+   /// Rest start: Lower, softer signal
+@@ -58,14 +66,14 @@ class AudioService {
+     // Lower pitch for rest (90% speed = lower tone)
+     await _pingPlayer.setPlaybackRate(0.9);
+     await _pingPlayer.setVolume(0.7); // Softer volume
+-    await _pingPlayer.play(AssetSource('audio/ping.mp3'));
++    await _pingPlayer.play(AssetSource('audio/rep_pulse.wav'));
+   }
+ 
+-  /// Set/phase completion: Boxing bell
++  /// Set/phase completion: End of set sound
+   Future<void> playPhaseComplete() async {
+     await _bellPlayer.stop();
+     await _bellPlayer.setPlaybackRate(1.0);
+-    await _bellPlayer.play(AssetSource('audio/boxing_bell.mp3'));
++    await _bellPlayer.play(AssetSource('audio/end_of_set.wav'));
+   }
+ 
+   /// Rep tick: Subtle progress indicator
+@@ -73,18 +81,33 @@ class AudioService {
+     await _pingPlayer.stop();
+     await _pingPlayer.setPlaybackRate(1.0);
+     await _pingPlayer.setVolume(0.5); // Quieter for non-critical feedback
+-    await _pingPlayer.play(AssetSource('audio/ping.mp3'));
++    await _pingPlayer.play(AssetSource('audio/rep_pulse.wav'));
+   }
+ 
+   /// Victory fanfare: Celebratory sound for workout completion
+-  /// TODO: Add a proper victory trumpet sound file (audio/victory.mp3)
+-  /// For now, uses whistle at higher pitch for triumphant effect
+   Future<void> playVictory() async {
+     await _victoryPlayer.stop();
+-    // High pitch for celebration (1.3x speed = triumphant tone)
+-    await _victoryPlayer.setPlaybackRate(1.3);
++    await _victoryPlayer.setPlaybackRate(1.0);
+     await _victoryPlayer.setVolume(1.0); // Full volume for celebration
+-    await _victoryPlayer.play(AssetSource('audio/whistle.mp3'));
++    await _victoryPlayer.play(AssetSource('audio/end_of_workout.wav'));
++  }
++
++  /// End of rest warning: Plays during last 3 seconds (or less) of rest period
++  /// If rest >= 3 seconds: plays full audio
++  /// If rest < 3 seconds: plays from appropriate starting point
++  Future<void> playEndOfRest({required int restDuration}) async {
++    await _endOfRestPlayer.stop();
++    await _endOfRestPlayer.setPlaybackRate(1.0);
++    await _endOfRestPlayer.setVolume(1.0);
++
++    // For rest periods < 3 seconds, adjust playback speed to fit duration
++    // This allows the sound to compress naturally into shorter rest periods
++    if (restDuration < 3) {
++      final speedMultiplier = 3.0 / restDuration;
++      await _endOfRestPlayer.setPlaybackRate(speedMultiplier);
++    }
++
++    await _endOfRestPlayer.play(AssetSource('audio/end_of_rest_with_pulses.wav'));
+   }
+ 
+   /// Legacy methods for backward compatibility
+@@ -103,6 +126,7 @@ class AudioService {
+     _bellPlayer.dispose();
+     _pingPlayer.dispose();
+     _victoryPlayer.dispose();
++    _endOfRestPlayer.dispose();
+     _isInitialized = false;
+   }
+ }
+diff --git c/lib/services/timer_service.dart w/lib/services/timer_service.dart
+index d64057c..c858f2f 100644
+--- c/lib/services/timer_service.dart
++++ w/lib/services/timer_service.dart
+@@ -24,6 +24,7 @@ class TimerService extends ChangeNotifier {
+   int _initialCountdownSeconds = 10;
+   int _elapsedWorkoutSeconds = 0;
+   bool _workoutStarted = false;
++  bool _endOfRestPlayed = false;
+   final AudioService _audioService;
+ 
+   TimerService({AudioService? audioService})
+@@ -107,6 +108,7 @@ class TimerService extends ChangeNotifier {
+   void _startRest() {
+     _state = TimerState.rest;
+     _currentCentiseconds = _restSeconds * 100;
++    _endOfRestPlayed = false; // Reset flag for new rest period
+     // Play softer rest start signal (Design System v2)
+     _audioService.playRestStart();
+     notifyListeners();
+@@ -172,9 +174,15 @@ class TimerService extends ChangeNotifier {
+       if (_state == TimerState.work && secondsRemaining <= 3 && secondsRemaining > 0) {
+         _audioService.playCountdownBeep(secondsRemaining: secondsRemaining);
+       }
+-      // Play escalating countdown beep in last 3 seconds of rest period
+-      if (_state == TimerState.rest && secondsRemaining <= 3 && secondsRemaining > 0) {
+-        _audioService.playCountdownBeep(secondsRemaining: secondsRemaining);
++      // Play end of rest sound during rest period
++      if (_state == TimerState.rest && !_endOfRestPlayed) {
++        // For rest >= 3 seconds: play when 3 seconds remain
++        // For rest < 3 seconds: play immediately (at start of rest)
++        final triggerTime = _restSeconds >= 3 ? 3 : _restSeconds;
++        if (secondsRemaining <= triggerTime && secondsRemaining > 0) {
++          _audioService.playEndOfRest(restDuration: _restSeconds);
++          _endOfRestPlayed = true;
++        }
+       }
+     }
+ 
+@@ -215,6 +223,7 @@ class TimerService extends ChangeNotifier {
+     _currentSet = 0;
+     _elapsedWorkoutSeconds = 0;
+     _workoutStarted = false;
++    _endOfRestPlayed = false;
+     notifyListeners();
+   }
+ 
+diff --git c/pubspec.yaml w/pubspec.yaml
+index ca42caf..d1743b9 100644
+--- c/pubspec.yaml
++++ w/pubspec.yaml
+@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+ # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
+ # In Windows, build-name is used as the major, minor, and patch parts
+ # of the product and file versions while build-number is used as the build suffix.
+-version: 1.1.0+2
++version: 1.2.0+5
+ 
+ environment:
+   sdk: '>=3.0.0 <4.0.0'
+diff --git c/scripts/increment_version.sh w/scripts/increment_version.sh
+new file mode 100755
+index 0000000..4bc94f4
+--- /dev/null
++++ w/scripts/increment_version.sh
+@@ -0,0 +1,22 @@
++#!/bin/bash
++
++# Script to increment the build number in pubspec.yaml
++# Version format: major.minor.patch+buildNumber
++
++PUBSPEC_FILE="pubspec.yaml"
++
++# Read current version
++current_version=$(grep "^version:" "$PUBSPEC_FILE" | sed 's/version: //')
++
++# Extract version name and build number
++version_name=$(echo "$current_version" | cut -d'+' -f1)
++build_number=$(echo "$current_version" | cut -d'+' -f2)
++
++# Increment build number
++new_build_number=$((build_number + 1))
++new_version="${version_name}+${new_build_number}"
++
++# Update pubspec.yaml
++sed -i "s/^version: .*/version: ${new_version}/" "$PUBSPEC_FILE"
++
++echo "Version incremented: ${current_version} → ${new_version}"

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -6,6 +6,7 @@ import '../models/workout_config.dart';
 import '../models/workout_template.dart';
 import '../providers/auth_provider.dart';
 import '../services/storage_service.dart';
+import '../services/dnd_service.dart';
 import 'timer_screen.dart';
 import 'history_screen.dart';
 import 'saved_workouts_screen.dart';
@@ -28,7 +29,10 @@ class _HomeScreenState extends State<HomeScreen> {
   BurpeeType _selectedType = BurpeeType.militarySixCount;
   WorkoutTemplate? _loadedTemplate;
   bool _powerUserMode = false;
+  bool _dndDuringWorkout = false;
   bool _isLoading = true;
+
+  final DndService _dndService = DndService();
 
   WorkoutConfig get _config => _configs[_selectedType]!;
 
@@ -45,11 +49,15 @@ class _HomeScreenState extends State<HomeScreen> {
     // Load power user mode preference
     final powerUserMode = await StorageService.isPowerUserMode();
 
+    // Load DND during workout preference
+    final dndDuringWorkout = await StorageService.isDndDuringWorkout();
+
     // Load last-used configuration
     final lastConfig = await StorageService.getLastUsedConfig();
 
     setState(() {
       _powerUserMode = powerUserMode;
+      _dndDuringWorkout = dndDuringWorkout;
       if (lastConfig != null) {
         _selectedType = lastConfig.burpeeType;
         _configs[lastConfig.burpeeType] = lastConfig;
@@ -76,6 +84,71 @@ class _HomeScreenState extends State<HomeScreen> {
           newValue
               ? 'Power User Mode enabled - Last workout auto-loads'
               : 'Power User Mode disabled',
+        ),
+        backgroundColor: Colors.green,
+      ),
+    );
+  }
+
+  /// Toggle Do Not Disturb during workout (Android only)
+  Future<void> _toggleDndDuringWorkout() async {
+    // Check if DND is supported on this platform
+    if (!_dndService.isSupported) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Do Not Disturb is only available on Android'),
+          backgroundColor: Colors.orange,
+        ),
+      );
+      return;
+    }
+
+    // If enabling, check for permission first
+    if (!_dndDuringWorkout) {
+      final hasPermission = await _dndService.hasPermission();
+      if (!hasPermission) {
+        if (!mounted) return;
+        final shouldRequest = await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('Permission Required'),
+            content: const Text(
+              'To enable Do Not Disturb during workouts, '
+              'the app needs permission to modify notification settings.\n\n'
+              'Would you like to open settings to grant this permission?',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context, false),
+                child: const Text('CANCEL'),
+              ),
+              ElevatedButton(
+                onPressed: () => Navigator.pop(context, true),
+                child: const Text('OPEN SETTINGS'),
+              ),
+            ],
+          ),
+        );
+
+        if (shouldRequest == true) {
+          await _dndService.requestPermission();
+        }
+        return;
+      }
+    }
+
+    final newValue = !_dndDuringWorkout;
+    await StorageService.setDndDuringWorkout(newValue);
+    setState(() => _dndDuringWorkout = newValue);
+
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          newValue
+              ? 'Do Not Disturb will be enabled during workouts'
+              : 'Do Not Disturb during workouts disabled',
         ),
         backgroundColor: Colors.green,
       ),
@@ -148,7 +221,7 @@ class _HomeScreenState extends State<HomeScreen> {
           child: Align(
             alignment: Alignment.topLeft,
             child: Text(
-              'v1.2.0',
+              'v1.3.0',
               style: Theme.of(context).textTheme.labelSmall?.copyWith(
                     color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
                   ),
@@ -158,6 +231,16 @@ class _HomeScreenState extends State<HomeScreen> {
         title: const Text('BurpeeBata'),
         centerTitle: true,
         actions: [
+          // Do Not Disturb toggle (Android only)
+          if (_dndService.isSupported)
+            IconButton(
+              icon: Icon(
+                _dndDuringWorkout ? Icons.do_not_disturb_on : Icons.do_not_disturb_off,
+                color: _dndDuringWorkout ? Colors.red : null,
+              ),
+              tooltip: _dndDuringWorkout ? 'DND During Workout (ON)' : 'DND During Workout (OFF)',
+              onPressed: _toggleDndDuringWorkout,
+            ),
           // Power User Mode toggle
           IconButton(
             icon: Icon(

--- a/lib/screens/timer_screen.dart
+++ b/lib/screens/timer_screen.dart
@@ -8,6 +8,7 @@ import '../models/burpee_type.dart';
 import '../services/timer_service.dart';
 import '../services/storage_service.dart';
 import '../services/workout_service.dart';
+import '../services/dnd_service.dart';
 import '../providers/auth_provider.dart';
 import '../theme/app_theme.dart';
 import 'package:uuid/uuid.dart';
@@ -25,6 +26,7 @@ class TimerScreen extends StatefulWidget {
 class _TimerScreenState extends State<TimerScreen> {
   final TimerService _timerService = TimerService();
   final WorkoutService _workoutService = WorkoutService();
+  final DndService _dndService = DndService();
   bool _isPaused = false;
   int _lastWholeSeconds = -1;
   TimerState _lastState = TimerState.idle;
@@ -34,7 +36,15 @@ class _TimerScreenState extends State<TimerScreen> {
     super.initState();
     WakelockPlus.enable();
     _timerService.addListener(_onTimerUpdate);
+    _initDnd();
     _startWorkout();
+  }
+
+  Future<void> _initDnd() async {
+    final dndEnabled = await StorageService.isDndDuringWorkout();
+    if (dndEnabled) {
+      await _dndService.enableDnd();
+    }
   }
 
   Future<void> _startWorkout() async {
@@ -44,6 +54,7 @@ class _TimerScreenState extends State<TimerScreen> {
   @override
   void dispose() {
     WakelockPlus.disable();
+    _dndService.restoreDnd();
     _timerService.removeListener(_onTimerUpdate);
     _timerService.dispose();
     super.dispose();

--- a/lib/services/dnd_service.dart
+++ b/lib/services/dnd_service.dart
@@ -1,0 +1,111 @@
+import 'dart:io';
+import 'package:do_not_disturb/do_not_disturb.dart';
+import 'package:flutter/foundation.dart';
+
+/// Service for managing Do Not Disturb mode during workouts.
+/// Only functional on Android; other platforms return no-op behavior.
+class DndService {
+  static final DndService _instance = DndService._internal();
+  factory DndService() => _instance;
+  DndService._internal();
+
+  final DoNotDisturbPlugin _dnd = DoNotDisturbPlugin();
+
+  bool _wasEnabled = false;
+  bool _didEnableDnd = false;
+
+  /// Check if DND feature is supported on this platform
+  bool get isSupported => !kIsWeb && Platform.isAndroid;
+
+  /// Check if the app has permission to modify DND settings
+  Future<bool> hasPermission() async {
+    if (!isSupported) return false;
+    try {
+      return await _dnd.isNotificationPolicyAccessGranted();
+    } catch (e) {
+      debugPrint('DndService: Error checking permission: $e');
+      return false;
+    }
+  }
+
+  /// Request permission to modify DND settings.
+  /// Opens system settings where user can grant permission.
+  Future<void> requestPermission() async {
+    if (!isSupported) return;
+    try {
+      await _dnd.openNotificationPolicyAccessSettings();
+    } catch (e) {
+      debugPrint('DndService: Error requesting permission: $e');
+    }
+  }
+
+  /// Get current DND status
+  Future<bool> isDndEnabled() async {
+    if (!isSupported) return false;
+    try {
+      final status = await _dnd.getDNDStatus();
+      return status != InterruptionFilter.all;
+    } catch (e) {
+      debugPrint('DndService: Error getting DND status: $e');
+      return false;
+    }
+  }
+
+  /// Enable DND mode, saving the previous state for later restoration.
+  /// Returns true if DND was successfully enabled.
+  Future<bool> enableDnd() async {
+    if (!isSupported) return false;
+
+    final hasAccess = await hasPermission();
+    if (!hasAccess) {
+      debugPrint('DndService: No permission to enable DND');
+      return false;
+    }
+
+    try {
+      // Save current state before changing
+      _wasEnabled = await isDndEnabled();
+
+      if (!_wasEnabled) {
+        // Only enable if not already enabled
+        // priority mode allows alarms and priority notifications
+        await _dnd.setInterruptionFilter(InterruptionFilter.priority);
+        _didEnableDnd = true;
+        debugPrint('DndService: DND enabled');
+      } else {
+        _didEnableDnd = false;
+        debugPrint('DndService: DND already enabled, not changing');
+      }
+      return true;
+    } catch (e) {
+      debugPrint('DndService: Error enabling DND: $e');
+      return false;
+    }
+  }
+
+  /// Restore DND to its previous state (before enableDnd was called).
+  /// Only disables DND if we were the ones who enabled it.
+  Future<void> restoreDnd() async {
+    if (!isSupported) return;
+
+    if (!_didEnableDnd) {
+      debugPrint('DndService: We did not enable DND, not restoring');
+      return;
+    }
+
+    final hasAccess = await hasPermission();
+    if (!hasAccess) {
+      debugPrint('DndService: No permission to restore DND');
+      return;
+    }
+
+    try {
+      // all = allow all notifications (DND off)
+      await _dnd.setInterruptionFilter(InterruptionFilter.all);
+      _didEnableDnd = false;
+      debugPrint('DndService: DND restored (disabled)');
+    } catch (e) {
+      debugPrint('DndService: Error restoring DND: $e');
+    }
+  }
+}

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -9,6 +9,7 @@ class StorageService {
   static const String _templatesKey = 'workout_templates';
   static const String _lastUsedConfigKey = 'last_used_config';
   static const String _powerUserModeKey = 'power_user_mode';
+  static const String _dndDuringWorkoutKey = 'dnd_during_workout';
 
   static Future<void> saveWorkout(Workout workout) async {
     final prefs = await SharedPreferences.getInstance();
@@ -136,5 +137,18 @@ class StorageService {
   static Future<bool> isPowerUserMode() async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getBool(_powerUserModeKey) ?? false;
+  }
+
+  /// Enable/disable Do Not Disturb during workouts (Android only)
+  static Future<void> setDndDuringWorkout(bool enabled) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_dndDuringWorkoutKey, enabled);
+  }
+
+  /// Check if DND during workout is enabled
+  /// Defaults to false for first-time users
+  static Future<bool> isDndDuringWorkout() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_dndDuringWorkoutKey) ?? false;
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -313,6 +313,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
+  do_not_disturb:
+    dependency: "direct main"
+    description:
+      name: do_not_disturb
+      sha256: "15f08e94b87c0c53d05e79b0c4f69487395905577f347cac45f02330194aa499"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   ed25519_edwards:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.0+5
+version: 1.3.0+7
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
@@ -46,6 +46,9 @@ dependencies:
 
   # Keep screen awake during workout
   wakelock_plus: ^1.2.8
+
+  # Do Not Disturb mode during workouts (Android only)
+  do_not_disturb: ^1.0.3
 
   # Audio playback for timer cues
   audioplayers: ^6.0.0

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -62,6 +62,7 @@ void main() {
     group('Initial Display', () {
       testWidgets('displays all number input fields with default values', (tester) async {
         await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
 
         // Verify all labels are present
         expect(find.text('Reps per Set'), findsOneWidget);
@@ -83,6 +84,7 @@ void main() {
 
       testWidgets('displays plus and minus buttons for each input', (tester) async {
         await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
 
         // There should be 6 add icons total (5 for inputs + 1 for "Create New" button)
         // and 5 remove icons (one per input)

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -1,9 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:burpeebata/screens/home_screen.dart';
 import '../helpers/firebase_test_helper.dart';
 
 void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
   Widget createTestWidget() {
     return wrapWithProviders(
       const MaterialApp(

--- a/test/services/dnd_service_test.dart
+++ b/test/services/dnd_service_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:burpeebata/services/dnd_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('DndService', () {
+    late DndService dndService;
+
+    setUp(() {
+      // Get the singleton instance
+      dndService = DndService();
+    });
+
+    group('singleton pattern', () {
+      test('returns same instance on multiple calls', () {
+        final instance1 = DndService();
+        final instance2 = DndService();
+
+        expect(identical(instance1, instance2), isTrue);
+      });
+    });
+
+    group('isSupported', () {
+      test('returns false on non-Android platforms in test environment', () {
+        // In Flutter test environment, Platform.isAndroid returns false
+        // and kIsWeb is false, but the test environment doesn't match Android
+        // The service should handle this gracefully
+        expect(dndService.isSupported, isFalse);
+      });
+    });
+
+    group('hasPermission', () {
+      test('returns false when platform is not supported', () async {
+        // On non-Android platforms, hasPermission should return false
+        final hasPermission = await dndService.hasPermission();
+        expect(hasPermission, isFalse);
+      });
+    });
+
+    group('isDndEnabled', () {
+      test('returns false when platform is not supported', () async {
+        // On non-Android platforms, isDndEnabled should return false
+        final isEnabled = await dndService.isDndEnabled();
+        expect(isEnabled, isFalse);
+      });
+    });
+
+    group('enableDnd', () {
+      test('returns false when platform is not supported', () async {
+        // On non-Android platforms, enableDnd should return false
+        final result = await dndService.enableDnd();
+        expect(result, isFalse);
+      });
+    });
+
+    group('restoreDnd', () {
+      test('completes without error when platform is not supported', () async {
+        // On non-Android platforms, restoreDnd should complete without error
+        await expectLater(
+          dndService.restoreDnd(),
+          completes,
+        );
+      });
+    });
+
+    group('requestPermission', () {
+      test('completes without error when platform is not supported', () async {
+        // On non-Android platforms, requestPermission should complete without error
+        await expectLater(
+          dndService.requestPermission(),
+          completes,
+        );
+      });
+    });
+  });
+}

--- a/test/services/storage_service_test.dart
+++ b/test/services/storage_service_test.dart
@@ -274,6 +274,28 @@ void main() {
       });
     });
 
+    group('DND during workout setting', () {
+      test('defaults to false', () async {
+        final isDndEnabled = await StorageService.isDndDuringWorkout();
+        expect(isDndEnabled, isFalse);
+      });
+
+      test('can be enabled', () async {
+        await StorageService.setDndDuringWorkout(true);
+
+        final isDndEnabled = await StorageService.isDndDuringWorkout();
+        expect(isDndEnabled, isTrue);
+      });
+
+      test('can be disabled', () async {
+        await StorageService.setDndDuringWorkout(true);
+        await StorageService.setDndDuringWorkout(false);
+
+        final isDndEnabled = await StorageService.isDndDuringWorkout();
+        expect(isDndEnabled, isFalse);
+      });
+    });
+
     group('template and workout isolation', () {
       test('templates and workouts are stored separately', () async {
         final template = WorkoutTemplate(


### PR DESCRIPTION
## Summary

- Add Do Not Disturb mode support during workouts (Android only)
- New `DndService` handles enabling/disabling DND with permission management
- Toggle button in home screen app bar to enable/disable the feature
- DND automatically enables when workout starts and restores previous state when workout ends
- Persisted user preference via `StorageService`

## Test plan

- [ ] Verify DND toggle appears on Android devices
- [ ] Verify DND toggle does NOT appear on iOS/web
- [ ] Test permission request flow when enabling DND for the first time
- [ ] Confirm DND activates when starting a workout (with setting enabled)
- [ ] Confirm DND restores to previous state when workout ends
- [ ] Verify preference persists across app restarts
- [ ] Run `make test` to verify all tests pass
